### PR TITLE
Add MIT License, update CODEOWNERS and bump version to 0.0.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone
 # opens a pull request.
-*       @VasilakiG @StefanAngelovski
+*       @vasilaking @StefanAngelovski

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # sparq root CMake
 cmake_minimum_required(VERSION 3.23)
 
-project(sparq VERSION 0.0.1 LANGUAGES CXX)
+project(sparq VERSION 0.0.2 LANGUAGES CXX)
 
 option(SPARQ_BUILD_HOST "Build host targets" ON)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 42dotmk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PlatformAbstractionLayer/Esp32/idf_component.yml
+++ b/PlatformAbstractionLayer/Esp32/idf_component.yml
@@ -1,3 +1,3 @@
-version: "0.0.1"
+version: "0.0.2"
 description: "base42's embedded framework (ESP32 backend)"
 url: "https://github.com/42dotmk/sparq"

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
             "kind": "git",
             "repository": "https://github.com/42dotmk/base42-vcpkg-registry",
             "packages": [],
-            "baseline": "3833bb46ea65c1db763c1c3f258a12cab41ff5ec"
+            "baseline": "a4f5dbe55df84ba70864f3ecfc7db5c2a06d75e5"
         }
     ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "sparq",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "base42's embedded framework",
     "dependencies": []
 }


### PR DESCRIPTION
# What does this PR do?
This pull request introduces several project-wide maintenance updates, including a version bump to `0.0.2`, the addition of a `LICENSE` file, and minor configuration changes to keep dependencies and ownership information current.

**Version updates:**
* Bumped project version to `0.0.2` in `CMakeLists.txt`, `PlatformAbstractionLayer/Esp32/idf_component.yml`, and `vcpkg.json` to reflect the latest release. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL4-R4) [[2]](diffhunk://#diff-96a2b4d1be18d65b579233a8bfad0701299cc4b9b9d54e1753ed323cbb4d2313L1-R1) [[3]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283L3-R3)

**Licensing:**
* Added an `MIT License` to the repository in the new `LICENSE` file.

**Dependency and configuration updates:**
* Updated the vcpkg registry baseline in `vcpkg-configuration.json` to the latest commit for improved package management.

**Repository ownership:**
* Fixed the username for `@vasilaking` in `.github/CODEOWNERS` to ensure correct code owner assignment.

>! Important
> The following lines in the `base42-vcpkg-registry/ports/sparq/portfile.cmake` need to be removed:
> ```
> # Policy bypass for missing LICENSE file
> set(VCPKG_POLICY_SKIP_COPYRIGHT_CHECK enabled)
> ```

closes https://github.com/42dotmk/sparq/issues/17

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before merging(don't check if not applicable):

- [ ] My code follows the style guidelines of this project, check [Contribution](CONTRIBUTION.md)
- [x] I have performed a self-review of my own code
- [ ] I have made the code self-documented[ [1] ](https://lackofimagination.org/2024/10/self-documenting-code/), [ [2] ](https://en.wikipedia.org/wiki/Self-documenting_code) and in hard-to-understand areas, commented my code, if applicable
- [x] I have made corresponding changes to the documentation, if applicable
- [ ] New and existing unit tests pass locally with my changes, if applicable
